### PR TITLE
CI: Add workflow to lint templates

### DIFF
--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -1,0 +1,35 @@
+name: Lint templates
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '51 6 * * *'
+
+permissions: {}
+
+jobs:
+  lint-templates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          repository: 'theupdateframework/tuf-on-ci-template'
+
+      - uses: reviewdog/action-actionlint@v1 # Not pinned because not a critical dependency
+        with:
+          filter_mode: nofilter
+
+
+  update-issue:
+    runs-on: ubuntu-latest
+    needs: [lint-templates]
+    if: always() && !cancelled()
+    permissions:
+      issues: 'write' # for modifying Issues
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Update an issue on failure
+        uses: ./actions/update-issue
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          success: ${{ !contains(needs.*.result, 'failure') }}


### PR DESCRIPTION
This is not added to the template project itself because then it would be part of the template (and I'd rather keep the template small).